### PR TITLE
Fixes for timestamping and autosave issues

### DIFF
--- a/vimbaApp/Db/Alvium_1800_U240m.template
+++ b/vimbaApp/Db/Alvium_1800_U240m.template
@@ -43,7 +43,6 @@ record(mbbo, "$(P)$(R)GC_DeviceScanType") {
   field(ZRST, "Areascan")
   field(ZRVL, "0")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -181,7 +180,6 @@ record(int64out, "$(P)$(R)GC_DevSFNCVerMajor") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionMajor")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -197,7 +195,6 @@ record(int64out, "$(P)$(R)GC_DevSFNCVerMinor") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionMinor")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -213,7 +210,6 @@ record(int64out, "$(P)$(R)GC_DevSFNCVerSubMin") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionSubMinor")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -389,7 +385,6 @@ record(ao, "$(P)$(R)GC_DeviceTemperature") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_DeviceTemperature")
   field(PREC, "3")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -413,7 +408,6 @@ record(int64out, "$(P)$(R)GC_DevFirUploadType") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceFirmwareUploadType")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1497,7 +1491,6 @@ record(mbbo, "$(P)$(R)GC_AcqFrameRateMode") {
   field(TWST, "ForceFrameRate")
   field(TWVL, "2")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2639,7 +2632,6 @@ record(mbbo, "$(P)$(R)GC_FileProcessStatus") {
   field(ONST, "UpdateNotRequire")
   field(ONVL, "1")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2680,7 +2672,6 @@ record(mbbo, "$(P)$(R)GC_FileStatus") {
   field(ONST, "Open")
   field(ONVL, "1")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2730,7 +2721,6 @@ record(mbbo, "$(P)$(R)GC_CorrectionMode") {
   field(ONST, "Off")
   field(ONVL, "0")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2796,7 +2786,6 @@ record(int64out, "$(P)$(R)GC_CorDataSize") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_CorrectionDataSize")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2812,7 +2801,6 @@ record(int64out, "$(P)$(R)GC_CorEntryType") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_CorrectionEntryType")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 

--- a/vimbaApp/Db/Alvium_1800_U240m.template
+++ b/vimbaApp/Db/Alvium_1800_U240m.template
@@ -43,6 +43,7 @@ record(mbbo, "$(P)$(R)GC_DeviceScanType") {
   field(ZRST, "Areascan")
   field(ZRVL, "0")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -115,6 +116,7 @@ record(mbbo, "$(P)$(R)GC_DevFirVerSelector") {
   field(ONST, "Programmed")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -147,6 +149,7 @@ record(mbbo, "$(P)$(R)GC_DevFirIDSelector") {
   field(ONST, "Supported")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -178,6 +181,7 @@ record(int64out, "$(P)$(R)GC_DevSFNCVerMajor") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionMajor")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -193,6 +197,7 @@ record(int64out, "$(P)$(R)GC_DevSFNCVerMinor") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionMinor")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -208,6 +213,7 @@ record(int64out, "$(P)$(R)GC_DevSFNCVerSubMin") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionSubMinor")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -248,6 +254,7 @@ record(mbbo, "$(P)$(R)GC_DevLinThrLimMode") {
   field(ONST, "Off")
   field(ONVL, "0")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -263,6 +270,7 @@ record(int64out, "$(P)$(R)GC_DevLinThrLimit") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceLinkThroughputLimit")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -314,6 +322,7 @@ record(mbbo, "$(P)$(R)GC_DevIndicatorMode") {
   field(TWST, "ErrorStatus")
   field(TWVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -329,6 +338,7 @@ record(int64out, "$(P)$(R)GC_DevIndLuminance") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceIndicatorLuminance")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -361,6 +371,7 @@ record(mbbo, "$(P)$(R)GC_DevTemSelector") {
   field(THST, "PHY")
   field(THVL, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -378,6 +389,7 @@ record(ao, "$(P)$(R)GC_DeviceTemperature") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_DeviceTemperature")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -401,6 +413,7 @@ record(int64out, "$(P)$(R)GC_DevFirUploadType") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceFirmwareUploadType")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -513,6 +526,7 @@ record(mbbo, "$(P)$(R)GC_SensorShutterMode") {
   field(TWST, "GlobalResetShutt")
   field(TWVL, "0x02")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -544,6 +558,7 @@ record(int64out, "$(P)$(R)GC_Width") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_Width")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -559,6 +574,7 @@ record(int64out, "$(P)$(R)GC_Height") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_Height")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -574,6 +590,7 @@ record(int64out, "$(P)$(R)GC_OffsetX") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_OffsetX")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -589,6 +606,7 @@ record(int64out, "$(P)$(R)GC_OffsetY") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_OffsetY")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -609,6 +627,7 @@ record(mbbo, "$(P)$(R)GC_BinningSelector") {
   field(ZRST, "Sensor")
   field(ZRVL, "0")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -633,6 +652,7 @@ record(mbbo, "$(P)$(R)GC_BinHorizontalMode") {
   field(ONST, "Average")
   field(ONVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -648,6 +668,7 @@ record(int64out, "$(P)$(R)GC_BinningHorizontal") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_BinningHorizontal")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -672,6 +693,7 @@ record(mbbo, "$(P)$(R)GC_BinVerticalMode") {
   field(ONST, "Average")
   field(ONVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -687,6 +709,7 @@ record(int64out, "$(P)$(R)GC_BinningVertical") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_BinningVertical")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -711,6 +734,7 @@ record(mbbo, "$(P)$(R)GC_DecHorizontalMode") {
   field(ONST, "Average")
   field(ONVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -726,6 +750,7 @@ record(int64out, "$(P)$(R)GC_DecHorizontal") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DecimationHorizontal")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -750,6 +775,7 @@ record(mbbo, "$(P)$(R)GC_DecVerticalMode") {
   field(ONST, "Average")
   field(ONVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -765,6 +791,7 @@ record(int64out, "$(P)$(R)GC_DecVertical") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DecimationVertical")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -784,6 +811,7 @@ record(bo, "$(P)$(R)GC_ReverseX") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 
@@ -803,6 +831,7 @@ record(bo, "$(P)$(R)GC_ReverseY") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 
@@ -855,6 +884,7 @@ record(mbbo, "$(P)$(R)GC_TestPattern") {
   field(EIST, "RGBVerticalRampM")
   field(EIVL, "0x08")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -937,6 +967,7 @@ record(mbbo, "$(P)$(R)GC_AutModRegSelector") {
   field(FRST, "FullImage")
   field(FRVL, "4")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -952,6 +983,7 @@ record(int64out, "$(P)$(R)GC_AutModRegionWidth") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_AutoModeRegionWidth")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -967,6 +999,7 @@ record(int64out, "$(P)$(R)GC_AutModRegHeight") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_AutoModeRegionHeight")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -982,6 +1015,7 @@ record(int64out, "$(P)$(R)GC_AutModRegOffsetX") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_AutoModeRegionOffsetX")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -997,6 +1031,7 @@ record(int64out, "$(P)$(R)GC_AutModRegOffsetY") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_AutoModeRegionOffsetY")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1029,6 +1064,7 @@ record(mbbo, "$(P)$(R)GC_IntConSelector") {
   field(THST, "IntensityControl")
   field(THVL, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1046,6 +1082,7 @@ record(ao, "$(P)$(R)GC_IntConOutDark") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_IntensityControllerOutliersDark")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1063,6 +1100,7 @@ record(ao, "$(P)$(R)GC_IntConOutBright") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_IntensityControllerOutliersBright")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1080,6 +1118,7 @@ record(ao, "$(P)$(R)GC_IntConTarget") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_IntensityControllerTarget")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1095,6 +1134,7 @@ record(int64out, "$(P)$(R)GC_IntConTolerance") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_IntensityControllerTolerance")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1119,6 +1159,7 @@ record(mbbo, "$(P)$(R)GC_IntConAlgorithm") {
   field(ONST, "FitRange")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1134,6 +1175,7 @@ record(int64out, "$(P)$(R)GC_IntControllerRate") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_IntensityControllerRate")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1170,6 +1212,7 @@ record(mbbo, "$(P)$(R)GC_IntConRegion") {
   field(FRST, "AutoModeRegion4")
   field(FRVL, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1187,6 +1230,7 @@ record(ao, "$(P)$(R)GC_ExposureAutoMin") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_ExposureAutoMin")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1204,6 +1248,7 @@ record(ao, "$(P)$(R)GC_ExposureAutoMax") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_ExposureAutoMax")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1221,6 +1266,7 @@ record(ao, "$(P)$(R)GC_GainAutoMin") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_GainAutoMin")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1238,6 +1284,7 @@ record(ao, "$(P)$(R)GC_GainAutoMax") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_GainAutoMax")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1255,6 +1302,7 @@ record(ao, "$(P)$(R)GC_BalWhiteAutoRate") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_BalanceWhiteAutoRate")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1272,6 +1320,7 @@ record(ao, "$(P)$(R)GC_BalWhiAutTol") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_BalanceWhiteAutoTolerance")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1296,6 +1345,7 @@ record(mbbo, "$(P)$(R)GC_BalWhiAutRegMode") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1320,6 +1370,7 @@ record(mbbo, "$(P)$(R)GC_ConAutIntConMode") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1344,6 +1395,7 @@ record(mbbo, "$(P)$(R)GC_IntAutoPrecedence") {
   field(ONST, "Minimizeblur")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1372,6 +1424,7 @@ record(mbbo, "$(P)$(R)GC_AcquisitionMode") {
   field(TWST, "Continuous")
   field(TWVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1415,6 +1468,7 @@ record(int64out, "$(P)$(R)GC_AcqFrameCount") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_AcquisitionFrameCount")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1443,6 +1497,7 @@ record(mbbo, "$(P)$(R)GC_AcqFrameRateMode") {
   field(TWST, "ForceFrameRate")
   field(TWVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1487,6 +1542,7 @@ record(mbbo, "$(P)$(R)GC_AcqStatusSelector") {
   field(SXST, "ReadoutActive")
   field(SXVL, "6")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1565,6 +1621,7 @@ record(mbbo, "$(P)$(R)GC_TriggerSelector") {
   field(TVST, "ExposureActive")
   field(TVVL, "12")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1601,6 +1658,7 @@ record(mbbo, "$(P)$(R)GC_TriggerActivation") {
   field(FRST, "LevelLow")
   field(FRVL, "4")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1618,6 +1676,7 @@ record(ao, "$(P)$(R)GC_TriggerDelay") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_TriggerDelay")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1635,6 +1694,7 @@ record(ao, "$(P)$(R)GC_ExposureTime") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_ExposureTime")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1655,6 +1715,7 @@ record(mbbo, "$(P)$(R)GC_GainSelector") {
   field(ZRST, "All")
   field(ZRVL, "0")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1672,6 +1733,7 @@ record(ao, "$(P)$(R)GC_Gain") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_Gain")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1692,6 +1754,7 @@ record(mbbo, "$(P)$(R)GC_BlaLevelSelector") {
   field(ZRST, "All")
   field(ZRVL, "0")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1709,6 +1772,7 @@ record(ao, "$(P)$(R)GC_BlackLevel") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_BlackLevel")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1737,6 +1801,7 @@ record(mbbo, "$(P)$(R)GC_BalRatioSelector") {
   field(TWST, "Blue")
   field(TWVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1754,6 +1819,7 @@ record(ao, "$(P)$(R)GC_BalanceRatio") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_BalanceRatio")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1782,6 +1848,7 @@ record(mbbo, "$(P)$(R)GC_BalanceWhiteAuto") {
   field(TWST, "Continuous")
   field(TWVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1799,6 +1866,7 @@ record(ao, "$(P)$(R)GC_Gamma") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_Gamma")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1816,6 +1884,7 @@ record(ao, "$(P)$(R)GC_Hue") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_Hue")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1833,6 +1902,7 @@ record(ao, "$(P)$(R)GC_Saturation") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_Saturation")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1852,6 +1922,7 @@ record(bo, "$(P)$(R)GC_ColTraEnable") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 
@@ -1872,6 +1943,7 @@ record(mbbo, "$(P)$(R)GC_ColTraSelector") {
   field(ZRST, "RGBtoRGB")
   field(ZRVL, "0")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1924,6 +1996,7 @@ record(mbbo, "$(P)$(R)GC_ColTraValSelector") {
   field(EIST, "Gain22")
   field(EIVL, "8")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1941,6 +2014,7 @@ record(ao, "$(P)$(R)GC_ColTraValue") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_ColorTransformationValue")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1973,6 +2047,7 @@ record(mbbo, "$(P)$(R)GC_LineSelector") {
   field(THST, "Line3")
   field(THVL, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1997,6 +2072,7 @@ record(mbbo, "$(P)$(R)GC_LineMode") {
   field(ONST, "Output")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2016,6 +2092,7 @@ record(bo, "$(P)$(R)GC_LineInverter") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 
@@ -2114,6 +2191,7 @@ record(mbbo, "$(P)$(R)GC_LineSource") {
   field(FFST, "UserOutput3")
   field(FFVL, "0x43")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2146,6 +2224,7 @@ record(mbbo, "$(P)$(R)GC_UseOutputSelector") {
   field(THST, "UserOutput3")
   field(THVL, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2165,6 +2244,7 @@ record(bo, "$(P)$(R)GC_UserOutputValue") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 
@@ -2189,6 +2269,7 @@ record(mbbo, "$(P)$(R)GC_InputDebounceMode") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2206,6 +2287,7 @@ record(ao, "$(P)$(R)GC_InputDebounceTime") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_InputDebounceTime")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -2230,6 +2312,7 @@ record(mbbo, "$(P)$(R)GC_OutDurationMode") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2247,6 +2330,7 @@ record(ao, "$(P)$(R)GC_OutDurationTime") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_OutputDurationTime")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -2283,6 +2367,7 @@ record(mbbo, "$(P)$(R)GC_UserSetSelector") {
   field(FRST, "UserSet4")
   field(FRVL, "5")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2333,6 +2418,7 @@ record(mbbo, "$(P)$(R)GC_UserSetDefault") {
   field(FRST, "UserSet4")
   field(FRVL, "5")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2348,6 +2434,7 @@ record(int64out, "$(P)$(R)GC_TestPendingAck") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_TestPendingAck")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2371,6 +2458,7 @@ record(int64out, "$(P)$(R)GC_GevSCPSPacketSize") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_GevSCPSPacketSize")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2411,6 +2499,7 @@ record(mbbo, "$(P)$(R)GC_FileSelector") {
   field(FVST, "FixedPatternNois")
   field(FVVL, "0x00000025")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2447,6 +2536,7 @@ record(mbbo, "$(P)$(R)GC_FilOpeSelector") {
   field(FRST, "Delete")
   field(FRVL, "4")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2478,6 +2568,7 @@ record(mbbo, "$(P)$(R)GC_FileOpenMode") {
   field(ONST, "Write")
   field(ONVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2501,6 +2592,7 @@ record(int64out, "$(P)$(R)GC_FileAccessLength") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_FileAccessLength")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2547,6 +2639,7 @@ record(mbbo, "$(P)$(R)GC_FileProcessStatus") {
   field(ONST, "UpdateNotRequire")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2587,6 +2680,7 @@ record(mbbo, "$(P)$(R)GC_FileStatus") {
   field(ONST, "Open")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2611,6 +2705,7 @@ record(mbbo, "$(P)$(R)GC_CorSelector") {
   field(ONST, "FixedPatternNois")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2635,6 +2730,7 @@ record(mbbo, "$(P)$(R)GC_CorrectionMode") {
   field(ONST, "Off")
   field(ONVL, "0")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2659,6 +2755,7 @@ record(mbbo, "$(P)$(R)GC_CorrectionSet") {
   field(ONST, "User")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2683,6 +2780,7 @@ record(mbbo, "$(P)$(R)GC_CorSetDefault") {
   field(ONST, "User")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2698,6 +2796,7 @@ record(int64out, "$(P)$(R)GC_CorDataSize") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_CorrectionDataSize")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2713,6 +2812,7 @@ record(int64out, "$(P)$(R)GC_CorEntryType") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_CorrectionEntryType")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2745,6 +2845,7 @@ record(mbbo, "$(P)$(R)GC_ColInterpolation") {
   field(THST, "HighQualityLinea")
   field(THVL, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2769,6 +2870,7 @@ record(mbbo, "$(P)$(R)GC_ConConMode") {
   field(ONST, "Expert")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2788,6 +2890,7 @@ record(bo, "$(P)$(R)GC_ContrastEnable") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 
@@ -2803,6 +2906,7 @@ record(int64out, "$(P)$(R)GC_ContrastDarkLimit") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ContrastDarkLimit")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2818,6 +2922,7 @@ record(int64out, "$(P)$(R)GC_ConBrightLimit") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ContrastBrightLimit")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2833,6 +2938,7 @@ record(int64out, "$(P)$(R)GC_ContrastShape") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ContrastShape")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2848,6 +2954,7 @@ record(int64out, "$(P)$(R)GC_ContrastValue") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ContrastValue")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2876,6 +2983,7 @@ record(mbbo, "$(P)$(R)GC_ContrastAuto") {
   field(TWST, "Continuous")
   field(TWVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 

--- a/vimbaApp/Db/Goldeye_G-130.template
+++ b/vimbaApp/Db/Goldeye_G-130.template
@@ -142,6 +142,7 @@ record(ao, "$(P)$(R)GC_GevIntSelector") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_GevInterfaceSelector")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -157,6 +158,7 @@ record(ao, "$(P)$(R)GC_GevMACAddress") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_GevMACAddress")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -176,6 +178,7 @@ record(bo, "$(P)$(R)GC_GevCurIPConLLA") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 
@@ -195,6 +198,7 @@ record(bo, "$(P)$(R)GC_GevCurIPConDHCP") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 
@@ -214,6 +218,7 @@ record(bo, "$(P)$(R)GC_GevCurIPConPerIP") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 
@@ -229,6 +234,7 @@ record(ao, "$(P)$(R)GC_GevTimestampValue") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_GevTimestampValue")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -275,6 +281,7 @@ record(mbbo, "$(P)$(R)GC_StreamHoldEnable") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -315,6 +322,7 @@ record(mbbo, "$(P)$(R)GC_DeviceType") {
   field(THST, "Peripheral")
   field(THVL, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -339,6 +347,7 @@ record(mbbo, "$(P)$(R)GC_DeviceScanType") {
   field(ONST, "Linescan")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -394,6 +403,7 @@ record(ao, "$(P)$(R)GC_DevSFNCVerMajor") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionMajor")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -409,6 +419,7 @@ record(ao, "$(P)$(R)GC_DevSFNCVerMinor") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionMinor")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -417,6 +428,7 @@ record(ai, "$(P)$(R)GC_DevSFNCVerSubMin_RBV") {
   field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionSubMinor")
   field(SCAN, "I/O Intr")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE" )
 }
 
@@ -424,6 +436,7 @@ record(ao, "$(P)$(R)GC_DevSFNCVerSubMin") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionSubMinor")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -460,6 +473,7 @@ record(mbbo, "$(P)$(R)GC_DeviceTLType") {
   field(FRST, "USB3Vision")
   field(FRVL, "4")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -515,6 +529,7 @@ record(mbbo, "$(P)$(R)GC_DevFirIDSelector") {
   field(ONST, "Supported")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -539,6 +554,7 @@ record(mbbo, "$(P)$(R)GC_DevFirVerSelector") {
   field(ONST, "Programmed")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -575,6 +591,7 @@ record(mbbo, "$(P)$(R)GC_DevTemSelector") {
   field(TWST, "MainBoard")
   field(TWVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -612,6 +629,7 @@ record(mbbo, "$(P)$(R)GC_DevRelHumSelector") {
   field(TWST, "MainBoard")
   field(TWVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -641,6 +659,7 @@ record(mbbo, "$(P)$(R)GC_DeviceFanSelector") {
   field(ZRST, "Main")
   field(ZRVL, "0")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -665,6 +684,7 @@ record(mbbo, "$(P)$(R)GC_DeviceFanMode") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -701,6 +721,7 @@ record(mbbo, "$(P)$(R)GC_SenTemControlMode") {
   field(TWST, "TemperatureContr")
   field(TWVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -716,6 +737,7 @@ record(ao, "$(P)$(R)GC_SenTemTarSetpoint") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_SensorTemperatureTargetSetpoint")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -740,6 +762,7 @@ record(mbbo, "$(P)$(R)GC_SenTemSetMode") {
   field(ONST, "Auto")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -763,6 +786,7 @@ record(ao, "$(P)$(R)GC_SenTemSetSelector") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_SensorTemperatureSetpointSelector")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -785,6 +809,7 @@ record(ao, "$(P)$(R)GC_SenTemSetValue") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_SensorTemperatureSetpointValue")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -842,6 +867,7 @@ record(ao, "$(P)$(R)GC_TimLatchValue") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_TimestampLatchValue")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -857,6 +883,7 @@ record(ao, "$(P)$(R)GC_DevStrChaSelector") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceStreamChannelSelector")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -872,6 +899,7 @@ record(ao, "$(P)$(R)GC_DevStrChaPacSize") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceStreamChannelPacketSize")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -891,6 +919,7 @@ record(bo, "$(P)$(R)GC_StrFraRatCon") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 
@@ -906,6 +935,7 @@ record(ao, "$(P)$(R)GC_DevLinkSelector") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceLinkSelector")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -923,6 +953,7 @@ record(ao, "$(P)$(R)GC_DevLinHeaTimeout") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_DeviceLinkHeartbeatTimeout")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -947,6 +978,7 @@ record(mbbo, "$(P)$(R)GC_DevLinThrLimMode") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -962,6 +994,7 @@ record(ao, "$(P)$(R)GC_DevLinThrLimit") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceLinkThroughputLimit")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -990,6 +1023,7 @@ record(mbbo, "$(P)$(R)GC_BanControlMode") {
   field(TWST, "Both")
   field(TWVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1028,6 +1062,7 @@ record(mbbo, "$(P)$(R)GC_TEC_AutRegulation") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1052,6 +1087,7 @@ record(mbbo, "$(P)$(R)GC_TEC_CoolHeatMode") {
   field(ONST, "Heat")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1067,6 +1103,7 @@ record(ao, "$(P)$(R)GC_TEC_Setpoints") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_TEC_Setpoints")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1082,6 +1119,7 @@ record(ao, "$(P)$(R)GC_TEC_StePowerLow") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_TEC_SteppingPowerLow")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1097,6 +1135,7 @@ record(ao, "$(P)$(R)GC_TEC_StePowerHigh") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_TEC_SteppingPowerHigh")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1112,6 +1151,7 @@ record(ao, "$(P)$(R)GC_TEC_VsetManual") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_TEC_VsetManual")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1127,6 +1167,7 @@ record(ao, "$(P)$(R)GC_TEC_VsetMax") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_TEC_VsetMax")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1144,6 +1185,7 @@ record(ao, "$(P)$(R)GC_TEC_Kp") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_TEC_Kp")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1161,6 +1203,7 @@ record(ao, "$(P)$(R)GC_TEC_Ki") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_TEC_Ki")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1178,6 +1221,7 @@ record(ao, "$(P)$(R)GC_TEC_Kd") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_TEC_Kd")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1193,6 +1237,7 @@ record(ao, "$(P)$(R)GC_AleTemSensorBoard") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_AlertTemperature_SensorBoard")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1208,6 +1253,7 @@ record(ao, "$(P)$(R)GC_SensorGainInc") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_SensorGainInc")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1232,6 +1278,7 @@ record(mbbo, "$(P)$(R)GC_BlaLevAdjustMode") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1277,6 +1324,7 @@ record(mbbo, "$(P)$(R)GC_AcqAutoStartMode") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1309,6 +1357,7 @@ record(mbbo, "$(P)$(R)GC_AcquisitionMode") {
   field(THST, "Recorder")
   field(THVL, "4")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1324,6 +1373,7 @@ record(ao, "$(P)$(R)GC_AcqFrameCount") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_AcquisitionFrameCount")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1341,6 +1391,7 @@ record(ao, "$(P)$(R)GC_AcqFrameRateAbs") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_AcquisitionFrameRateAbs")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1365,6 +1416,7 @@ record(ao, "$(P)$(R)GC_RecPreEventCount") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_RecorderPreEventCount")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1397,6 +1449,7 @@ record(mbbo, "$(P)$(R)GC_TriggerSelector") {
   field(THST, "AcquisitionRecor")
   field(THVL, "6")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1433,6 +1486,7 @@ record(mbbo, "$(P)$(R)GC_TriggerActivation") {
   field(FRST, "LevelLow")
   field(FRVL, "4")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1450,6 +1504,7 @@ record(ao, "$(P)$(R)GC_TriggerDelayAbs") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_TriggerDelayAbs")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1467,6 +1522,7 @@ record(ao, "$(P)$(R)GC_TriggerDelay") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_TriggerDelay")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1503,6 +1559,7 @@ record(mbbo, "$(P)$(R)GC_ContrastAuto") {
   field(FRST, "UserAutoRegion")
   field(FRVL, "4")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1520,6 +1577,7 @@ record(ao, "$(P)$(R)GC_ExposureTimeAbs") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_ExposureTimeAbs")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1537,6 +1595,7 @@ record(ao, "$(P)$(R)GC_ExposureTime") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_ExposureTime")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1561,6 +1620,7 @@ record(mbbo, "$(P)$(R)GC_IntegrationMode") {
   field(ONST, "IntegrateThenRea")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1576,6 +1636,7 @@ record(ao, "$(P)$(R)GC_ExpAutoTarget") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ExposureAutoTarget")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1600,6 +1661,7 @@ record(mbbo, "$(P)$(R)GC_ExposureAutoAlg") {
   field(ONST, "FitRange")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1615,6 +1677,7 @@ record(ao, "$(P)$(R)GC_ExposureAutoMin") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ExposureAutoMin")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1630,6 +1693,7 @@ record(ao, "$(P)$(R)GC_ExposureAutoMax") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ExposureAutoMax")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1645,6 +1709,7 @@ record(ao, "$(P)$(R)GC_ExposureAutoRate") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ExposureAutoRate")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1660,6 +1725,7 @@ record(ao, "$(P)$(R)GC_ExpAutOutBright") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ExposureAutoOutliersBright")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1675,6 +1741,7 @@ record(ao, "$(P)$(R)GC_ExpAutOutDark") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ExposureAutoOutliersDark")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1690,6 +1757,7 @@ record(ao, "$(P)$(R)GC_ExpAutoAdjustTol") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ExposureAutoAdjustTol")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1705,6 +1773,7 @@ record(ao, "$(P)$(R)GC_ConUserInputMin") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ContrastUserInputMin")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1720,6 +1789,7 @@ record(ao, "$(P)$(R)GC_ConUserInputMax") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ContrastUserInputMax")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1735,6 +1805,7 @@ record(ao, "$(P)$(R)GC_ConAutIntMin") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ContrastAutoIntensityMin")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1750,6 +1821,7 @@ record(ao, "$(P)$(R)GC_ConAutIntMax") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ContrastAutoIntensityMax")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1765,6 +1837,7 @@ record(ao, "$(P)$(R)GC_AutModRegOffsetX") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_AutoModeRegionOffsetX")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1780,6 +1853,7 @@ record(ao, "$(P)$(R)GC_AutModRegOffsetY") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_AutoModeRegionOffsetY")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1795,6 +1869,7 @@ record(ao, "$(P)$(R)GC_AutModRegionWidth") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_AutoModeRegionWidth")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1810,6 +1885,7 @@ record(ao, "$(P)$(R)GC_AutModRegHeight") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_AutoModeRegionHeight")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1827,6 +1903,7 @@ record(ao, "$(P)$(R)GC_AutModOutBright") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_AutoModeOutliersBright")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1844,6 +1921,7 @@ record(ao, "$(P)$(R)GC_AutModOutDark") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_AutoModeOutliersDark")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1868,6 +1946,7 @@ record(mbbo, "$(P)$(R)GC_AutModRegDimOut") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1885,6 +1964,7 @@ record(ao, "$(P)$(R)GC_Gain") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_D_Gain")
   field(PREC, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PREC PINI VAL" )
 }
 
@@ -1905,6 +1985,7 @@ record(mbbo, "$(P)$(R)GC_GainSelector") {
   field(ZRST, "All")
   field(ZRVL, "0")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -1920,6 +2001,7 @@ record(ao, "$(P)$(R)GC_GevSCPSPacketSize") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_GevSCPSPacketSize")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -1987,6 +2069,7 @@ record(ao, "$(P)$(R)GC_BinningHorizontal") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_BinningHorizontal")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2002,6 +2085,7 @@ record(ao, "$(P)$(R)GC_BinningVertical") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_BinningVertical")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2022,6 +2106,7 @@ record(mbbo, "$(P)$(R)GC_BinHorizontalMode") {
   field(ZRST, "Sum")
   field(ZRVL, "0")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2042,6 +2127,7 @@ record(mbbo, "$(P)$(R)GC_BinVerticalMode") {
   field(ZRST, "Sum")
   field(ZRVL, "0")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2073,6 +2159,7 @@ record(ao, "$(P)$(R)GC_Width") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_Width")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2088,6 +2175,7 @@ record(ao, "$(P)$(R)GC_Height") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_Height")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2103,6 +2191,7 @@ record(ao, "$(P)$(R)GC_OffsetX") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_OffsetX")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2118,6 +2207,7 @@ record(ao, "$(P)$(R)GC_OffsetY") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_OffsetY")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2182,6 +2272,7 @@ record(mbbo, "$(P)$(R)GC_LineInSelector") {
   field(SVST, "LineIn8")
   field(SVVL, "7")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2197,6 +2288,7 @@ record(ao, "$(P)$(R)GC_LinInGlitchFilter") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_LineInGlitchFilter")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2212,6 +2304,7 @@ record(ao, "$(P)$(R)GC_LineOutLevels") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_LineOutLevels")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2244,6 +2337,7 @@ record(mbbo, "$(P)$(R)GC_LineOutSelector") {
   field(THST, "LineOut4")
   field(THVL, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2324,6 +2418,7 @@ record(mbbo, "$(P)$(R)GC_LineOutSource") {
   field(FFST, "Strobe1")
   field(FFVL, "16")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2348,6 +2443,7 @@ record(mbbo, "$(P)$(R)GC_LineOutPolarity") {
   field(ONST, "Invert")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2420,6 +2516,7 @@ record(mbbo, "$(P)$(R)GC_StrobeSource") {
   field(TTST, "LineIn8")
   field(TTVL, "15")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2444,6 +2541,7 @@ record(mbbo, "$(P)$(R)GC_StrDurationMode") {
   field(ONST, "Controlled")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2459,6 +2557,7 @@ record(ao, "$(P)$(R)GC_StrobeDelay") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_StrobeDelay")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2474,6 +2573,7 @@ record(ao, "$(P)$(R)GC_StrobeDuration") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_StrobeDuration")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2554,6 +2654,7 @@ record(mbbo, "$(P)$(R)GC_EventSelector") {
   field(FFST, "Line5RisingEdge")
   field(FFVL, "40018")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2578,6 +2679,7 @@ record(mbbo, "$(P)$(R)GC_EventNotification") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2593,6 +2695,7 @@ record(ao, "$(P)$(R)GC_EventsEnable1") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_EventsEnable1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -2865,6 +2968,7 @@ record(mbbo, "$(P)$(R)GC_UserSetSelector") {
   field(FVST, "UserSet5")
   field(FVVL, "5")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2919,6 +3023,7 @@ record(mbbo, "$(P)$(R)GC_UseSetDefSelector") {
   field(FVST, "UserSet5")
   field(FVVL, "5")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2943,6 +3048,7 @@ record(mbbo, "$(P)$(R)GC_NUCMode") {
   field(ONST, "TwoPoint")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -2958,6 +3064,7 @@ record(ao, "$(P)$(R)GC_NUCDatasetActive") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_NUCDatasetActive")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3021,6 +3128,7 @@ record(mbbo, "$(P)$(R)GC_NUCDatasetAuto") {
   field(TWST, "Continuous")
   field(TWVL, "2")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -3036,6 +3144,7 @@ record(ao, "$(P)$(R)GC_NUCDatSelector") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_NUCDatasetSelector")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3093,6 +3202,7 @@ record(ao, "$(P)$(R)GC_NUCDatNodSelector") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_NUCDatasetNodeSelector")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3124,6 +3234,7 @@ record(ao, "$(P)$(R)GC_BCDatOffsetValue") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_BCDatasetOffsetValue")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3139,6 +3250,7 @@ record(ao, "$(P)$(R)GC_BCDatROIHeight") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_BCDatasetROIHeight")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3154,6 +3266,7 @@ record(ao, "$(P)$(R)GC_BCDatROIOffsetX") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_BCDatasetROIOffsetX")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3169,6 +3282,7 @@ record(ao, "$(P)$(R)GC_BCDatROIOffsetY") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_BCDatasetROIOffsetY")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3184,6 +3298,7 @@ record(ao, "$(P)$(R)GC_BCDatasetROIWidth") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_BCDatasetROIWidth")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3206,6 +3321,7 @@ record(ao, "$(P)$(R)GC_BCIntFrameCount") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_BCIntegrationFrameCount")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3230,6 +3346,7 @@ record(mbbo, "$(P)$(R)GC_BCIntegrationMode") {
   field(ONST, "FrameBuffer")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -3269,6 +3386,7 @@ record(mbbo, "$(P)$(R)GC_BCMode") {
   field(THST, "ReferenceImage")
   field(THVL, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -3307,6 +3425,7 @@ record(mbbo, "$(P)$(R)GC_DPCMode") {
   field(ONST, "On")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -3322,6 +3441,7 @@ record(ao, "$(P)$(R)GC_DPCDatasetActive") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DPCDatasetActive")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3345,6 +3465,7 @@ record(ao, "$(P)$(R)GC_DPCDatSelector") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DPCDatasetSelector")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3392,6 +3513,7 @@ record(mbbo, "$(P)$(R)GC_LUTSelector") {
   field(THST, "Blue")
   field(THVL, "3")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -3411,6 +3533,7 @@ record(bo, "$(P)$(R)GC_LUTEnable") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 
@@ -3426,6 +3549,7 @@ record(ao, "$(P)$(R)GC_LUTIndex") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_LUTIndex")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3441,6 +3565,7 @@ record(ao, "$(P)$(R)GC_LUTValue") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_LUTValue")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3472,6 +3597,7 @@ record(ao, "$(P)$(R)GC_LUTDatSelector") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_LUTDatasetSelector")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3487,6 +3613,7 @@ record(ao, "$(P)$(R)GC_LUTDatasetActive") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_LUTDatasetActive")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3520,6 +3647,7 @@ record(bo, "$(P)$(R)GC_ChunkModeActive") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 
@@ -3623,6 +3751,7 @@ record(mbbo, "$(P)$(R)GC_FileSelector") {
   field(FFST, "NUC_009")
   field(FFVL, "0x01009")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -3671,6 +3800,7 @@ record(mbbo, "$(P)$(R)GC_FilOpeSelector") {
   field(SVST, "WriteDescription")
   field(SVVL, "7")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -3702,6 +3832,7 @@ record(mbbo, "$(P)$(R)GC_FileOpenMode") {
   field(ONST, "Write")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -3726,6 +3857,7 @@ record(mbbo, "$(P)$(R)GC_FileOpenAttribute") {
   field(ONST, "Append")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -3749,6 +3881,7 @@ record(ao, "$(P)$(R)GC_FileAccessLength") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_FileAccessLength")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3817,6 +3950,7 @@ record(mbbo, "$(P)$(R)GC_FileStatus") {
   field(ONST, "Open")
   field(ONVL, "1")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -3839,6 +3973,7 @@ record(ao, "$(P)$(R)GC_XLReadSize") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_XLReadSize")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3854,6 +3989,7 @@ record(ao, "$(P)$(R)GC_XLWriteSize") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_XLWriteSize")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -3914,6 +4050,7 @@ record(mbbo, "$(P)$(R)GC_PvDumTriSelector") {
   field(THST, "AcquisitionRecor")
   field(THVL, "6")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -3974,6 +4111,7 @@ record(mbbo, "$(P)$(R)GC_PvDumFraStaTriMod") {
   field(TEST, "Software")
   field(TEVL, "2147483658")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -4034,6 +4172,7 @@ record(mbbo, "$(P)$(R)GC_PvDumTriggerMode") {
   field(TEST, "Software")
   field(TEVL, "2147483658")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZRSV ONSV TWSV THSV FRSV FVSV SXSV SVSV EISV NISV TESV ELSV TVSV TTSV FTSV FFSV TSE PINI VAL" )
 }
 
@@ -4049,6 +4188,7 @@ record(ao, "$(P)$(R)GC_FraStaTriDelay") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_FrameStartTriggerDelay")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -4064,6 +4204,7 @@ record(ao, "$(P)$(R)GC_ExposureValue") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_ExposureValue")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -4115,6 +4256,7 @@ record(bo, "$(P)$(R)GC_StrFraRatConPvApi") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(DISA, "0")
+  field(PINI, "YES")
   info( autosaveFields, "DESC ZSV OSV TSE PINI VAL" )
 }
 

--- a/vimbaApp/Db/Goldeye_G-130.template
+++ b/vimbaApp/Db/Goldeye_G-130.template
@@ -403,7 +403,6 @@ record(ao, "$(P)$(R)GC_DevSFNCVerMajor") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionMajor")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -419,7 +418,6 @@ record(ao, "$(P)$(R)GC_DevSFNCVerMinor") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionMinor")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 
@@ -428,7 +426,6 @@ record(ai, "$(P)$(R)GC_DevSFNCVerSubMin_RBV") {
   field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionSubMinor")
   field(SCAN, "I/O Intr")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE" )
 }
 
@@ -436,7 +433,6 @@ record(ao, "$(P)$(R)GC_DevSFNCVerSubMin") {
   field(DTYP, "asynInt64")
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_DeviceSFNCVersionSubMinor")
   field(DISA, "0")
-  field(PINI, "YES")
   info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE PINI VAL" )
 }
 

--- a/vimbaApp/Db/vimba.template
+++ b/vimbaApp/Db/vimba.template
@@ -44,6 +44,15 @@ record(bi, "$(P)$(R)UniqueIdMode_RBV")
    field(SCAN, "I/O Intr")
 }
 
+record(bi, "$(P)$(R)PackedPixelFormat_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT) 0)VMB_PACKED_PIXEL_FORMAT")
+    field(ZNAM, "NO")
+    field(ONAM, "YES")
+    field(SCAN, "I/O Intr")
+}
+
 ## Convert pixel format
 record(mbbo, "$(P)$(R)ConvertPixelFormat") {
   field(PINI, "YES")
@@ -152,22 +161,32 @@ record(mbbi, "$(P)$(R)GC_StreamType_RBV") {
 
 # MCB - These are totally bogus and copied from the aravisGige.
 # TBD - Fix this!!
-record( ao, "$(P)$(R)XmitRate" )
+record( calc, "$(P)$(R)XmitScale" )
 {
-    field( DOL,  "125e6" )
-    field( EGU,  "Bytes/Sec" )
+    field( INPA, "$(P)$(R)PackedPixelFormat_RBV CPP MS" )
+    field( INPB, "$(P)$(R)BitsPerPixel_RBV CPP MS" )
+    field( CALC, "A=0?1:B/16" )
     field( PREC, "3" )
-    field( PINI, "YES" )
-    info( autosaveFields, "VAL" )
-}   
+}
 
-record( ao, "$(P)$(R)CamProcDelay" )
+record( ao, "$(P)$(R)ProcDelayPerPixel" )
 {
-    field( DOL,  "10e-3" )
-    field( EGU,  "Sec" )
-    field( PREC, "3" ) 
+    field( DOL,  "1.27e-10" )
+    field( EGU,  "Sec/px" )
+    field( PREC, "12" )
     field( PINI, "YES" )
     info( autosaveFields, "VAL" )
+}
+
+record( calc, "$(P)$(R)CamProcDelay" )
+{
+    field( INPA, "$(P)$(R)PackedPixelFormat_RBV CPP MS" )
+    field( INPB, "$(P)$(R)ProcDelayPerPixel CPP MS" )
+    field( INPC, "$(P)$(R)ArraySizeX_RBV CPP MS" )
+    field( INPD, "$(P)$(R)ArraySizeY_RBV CPP MS" )
+    field( CALC, "A=0?0:B*C*D" )
+    field( EGU,  "Sec" )
+    field( PREC, "5" )
 }   
 
 # vimba DataType Enumerations
@@ -175,17 +194,17 @@ record( ao, "$(P)$(R)CamProcDelay" )
 record( calc, "$(P)$(R)XmitDelay" )
 {
     field( INPA, "$(P)$(R)ArraySize_RBV CP MS" )
-    field( INPB, "$(P)$(R)XmitRate CPP MS" )
+    field( INPB, "$(P)$(R)GC_DevLinThrLimit_RBV CPP MS" )
     field( INPC, "$(P)$(R)CamProcDelay CPP MS" )
-    field( INPD, "$(P)$(R)DataType_RBV CPP MS" )
-    field( CALC, "(D&2)*A/B+C" )
+    field( INPD, "$(P)$(R)XmitScale CPP MS" )
+    field( CALC, "D*A/B+C" )
     field( EGU,  "Sec" )
     field( PREC, "4" )
 }   
 
 record( ao, "$(P)$(R)DriverProcDelay" )
 {
-    field( DOL,  "1.0e-6" )
+    field( DOL,  "2.15e-3" )
     field( EGU,  "Sec" )
     field( PREC, "3" ) 
     field( PINI, "YES" )

--- a/vimbaApp/Db/vimba_settings.req
+++ b/vimbaApp/Db/vimba_settings.req
@@ -12,7 +12,3 @@ $(P)$(R)PixelFormat
 $(P)$(R)TimeStampMode
 $(P)$(R)UniqueIdMode
 $(P)$(R)ConvertPixelFormat
-# SLAC settings:
-$(P)$(R)XmitRate
-$(P)$(R)CamProcDelay
-$(P)$(R)DriverProcDelay

--- a/vimbaApp/src/ADVimba.cpp
+++ b/vimbaApp/src/ADVimba.cpp
@@ -157,9 +157,10 @@ ADVimba::ADVimba(const char *portName, const char *cameraId,
         return;
     }
 
-    createParam("VMB_CONVERT_PIXEL_FORMAT",     asynParamInt32,   &VMBConvertPixelFormat);
-    createParam("VMB_TIME_STAMP_MODE",          asynParamInt32,   &VMBTimeStampMode);
-    createParam("VMB_UNIQUE_ID_MODE",           asynParamInt32,   &VMBUniqueIdMode);
+    createParam(VMBConvertPixelFormatString,     asynParamInt32,   &VMBConvertPixelFormat);
+    createParam(VMBTimeStampModeString,          asynParamInt32,   &VMBTimeStampMode);
+    createParam(VMBUniqueIdModeString,           asynParamInt32,   &VMBUniqueIdMode);
+    createParam(VMBPackedPixelFormatString,      asynParamInt32,   &VMBPackedPixelFormat);
 
     /* Set initial values of some parameters */
     setIntegerParam(NDDataType, NDUInt8);
@@ -204,37 +205,51 @@ asynStatus ADVimba::writeInt32( asynUser *pasynUser, epicsInt32 value)
 
     // Do this in the super!
     status = ADGenICam::writeInt32(pasynUser, value);
-#ifdef NDBitsPerPixelString
     // Here, we just catch changes to the image format.
     if (function == GCPixelFormat) {
-	int bits = 0;
-	switch (value) {
+      int bits = 0;
+      int packed = 0;
+      switch (value) {
         case VmbPixelFormatMono8:
-	    bits = 8;
-	    break;
-	case VmbPixelFormatMono10:
+          bits = 8;
+          packed = 0;
+          break;
+        case VmbPixelFormatMono10:
+          bits = 10;
+          packed = 0;
+          break;
         case VmbPixelFormatMono10p:
-	    bits = 10;
-	    break;
+          bits = 10;
+          packed = 1;
+          break;
         case VmbPixelFormatMono12:
+          bits = 12;
+          packed = 0;
+          break;
         case VmbPixelFormatMono12Packed:
         case VmbPixelFormatMono12p:
-	    bits = 12;
-	    break;
+          bits = 12;
+          packed = 1;
+          break;
         case VmbPixelFormatMono14:
-	    bits = 14;
-	    break;
+          bits = 14;
+          packed = 0;
+          break;
         case VmbPixelFormatMono16:
-	    bits = 16;
-	    break;
-	default: /* A color mode.  Let's skip for now. */
-	    bits = 8;
-	    break;
-	}
-	setIntegerParam(NDBitsPerPixel, bits);
-	callParamCallbacks();
-    }
+          bits = 16;
+          packed = 0;
+          break;
+        default: /* A color mode.  Let's skip for now. */
+          bits = 8;
+          packed = 0;
+          break;
+      }
+#ifdef NDBitsPerPixelString
+      setIntegerParam(NDBitsPerPixel, bits);
 #endif
+      setIntegerParam(VMBPackedPixelFormat, packed);
+      callParamCallbacks();
+    }
     return status;
 }
 

--- a/vimbaApp/src/ADVimba.cpp
+++ b/vimbaApp/src/ADVimba.cpp
@@ -561,19 +561,20 @@ asynStatus ADVimba::processFrame(FramePtr pFrame)
         pRaw->uniqueId = uniqueId_;
     }
     uniqueId_++;
-    updateTimeStamp(&pRaw->epicsTS);
-    getIntegerParam(VMBTimeStampMode, &timeStampMode);
     // Set the timestamps in the buffer
+    getIntegerParam(VMBTimeStampMode, &timeStampMode);
     {
-	extern double camera_ts;
+        extern double camera_ts;
         VmbUint64_t timeStamp;
         pFrame->GetTimestamp(timeStamp);
-	camera_ts = pRaw->timeStamp = timeStamp / 1e9;
-	if (timeStampMode == TimeStampCamera)
-	    pRaw->timeStamp = camera_ts;
+        camera_ts = timeStamp / 1.e9;
+        pRaw->timeStamp = camera_ts;
+        if (timeStampMode == TimeStampCamera)
+          pRaw->timeStamp = camera_ts;
         else
-	    pRaw->timeStamp = pRaw->epicsTS.secPastEpoch + pRaw->epicsTS.nsec/1e9;
+          pRaw->timeStamp = pRaw->epicsTS.secPastEpoch + pRaw->epicsTS.nsec / 1.e9;
     }
+    updateTimeStamp(&pRaw->epicsTS);
 
     // Get any attributes that have been defined for this driver        
     getAttributes(pRaw->pAttributeList);

--- a/vimbaApp/src/ADVimba.h
+++ b/vimbaApp/src/ADVimba.h
@@ -16,6 +16,7 @@ using namespace std;
 #define VMBConvertPixelFormatString  "VMB_CONVERT_PIXEL_FORMAT"   // asynParamInt32, R/W
 #define VMBTimeStampModeString       "VMB_TIME_STAMP_MODE"        // asynParamInt32, R/O
 #define VMBUniqueIdModeString        "VMB_UNIQUE_ID_MODE"         // asynParamInt32, R/O
+#define VMBPackedPixelFormatString   "VMB_PACKED_PIXEL_FORMAT"    // asynParamInt32, R/O
 
 class ADVimbaFrameObserver : virtual public IFrameObserver {
 public:
@@ -54,9 +55,11 @@ public:
 private:
     inline asynStatus checkError(VmbErrorType error, const char *functionName, const char *message);
     int VMBConvertPixelFormat;
-#define FIRST_VMB_PARAM VMBConvertPixelFormat;
     int VMBTimeStampMode;
     int VMBUniqueIdMode;
+    int VMBPackedPixelFormat;
+#define FIRST_VMB_PARAM VMBConvertPixelFormat
+#define LAST_VMB_PARAM VMBPackedPixelFormat
 
     /* Local methods to this class */
     asynStatus startCapture();


### PR DESCRIPTION
This pull request has fixes for a few issues that I encountered when trying to set up a camera IOC that used this module in the RIX hutch in LCLS

- The INTERNAL timestamp policy  for timeStampFifo was not working at any rates above 1Hz since the internal timestamp was being truncated to whole seconds due to integer division.
- Fixed the SYNCED timestamp policy. All the records for calculating the expected arrival time of frames where just copy-pasted from the module for GigE cameras. The records have been updated so it works now for different image sizes and bit depths (packed vs non-packed pixel modes also affect the arrival time).
- Many of the output records did not proc on startup of the IOC so restored autosave values weren't actually propagating to the camera.