### PR TITLE
Make the number of buffers used by vimbaSDK configurable

### DIFF
--- a/vimbaApp/src/ADVimba.h
+++ b/vimbaApp/src/ADVimba.h
@@ -34,7 +34,8 @@ class ADVimba : public ADGenICam
 {
 public:
     ADVimba(const char *portName, const char *cameraId,
-            size_t maxMemory, int priority, int stackSize);
+            size_t maxMemory, int priority, int stackSize,
+            int bufferCount);
 
     // virtual methods to override from ADGenICam
     virtual asynStatus writeInt32( asynUser *pasynUser, epicsInt32 value);
@@ -76,6 +77,7 @@ private:
     epicsEventId startEventId_;
     epicsEventId newFrameEventId_;
     int uniqueId_;
+    int bufferCount_;
     
     std::vector<string> TLStatisticsFeatureNames_;
 


### PR DESCRIPTION
This is a change to the module I made as part of debugging issues with the MFX timetool alvium. Originally the number of buffers the vimbaSDK could use for acquiring frames was hard-coded to ten. This lets you configure the number of buffers. The intention is to pair this with a change in vimbaCam IOC, so the number of buffers can be changed from the default in the IOC instances cfg file.